### PR TITLE
Fix path to systemd system directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Also copy the following:
 ```
 sudo cp ./requirements/usr/bin/hyperpixel-init /usr/bin/
 sudo cp ./requirements/usr/bin/hyperpixel-touch /usr/bin/
-sudo cp ./requirements/usr/lib/systemd/system/hyperpixel-init.service /usr/lib/systemd/system/
-sudo cp ./requirements/usr/lib/systemd/system/hyperpixel-touch.service /usr/lib/systemd/system/
+sudo cp ./requirements/usr/lib/systemd/system/hyperpixel-init.service /etc/systemd/system/
+sudo cp ./requirements/usr/lib/systemd/system/hyperpixel-touch.service /etc/systemd/system/
 ```
 
 Make sure the relevant files are executable:

--- a/setup.sh
+++ b/setup.sh
@@ -215,7 +215,7 @@ sudo rm /etc/init.d/hyperpixel-touch.sh &> /dev/null # remove old init script
 initlist=( "hyperpixel-init" "hyperpixel-touch" )
 
 for initfile in ${initlist[@]}; do
-    sudo cp ./requirements/usr/lib/systemd/system/$initfile.service /usr/lib/systemd/system/ &> /dev/null
+    sudo cp ./requirements/usr/lib/systemd/system/$initfile.service /etc/systemd/system/ &> /dev/null
     sudo systemctl enable $initfile
 done
 


### PR DESCRIPTION
Prior to this commit the unit service files were being copied to `/usr/lib/systemd/system/` which does not exist, this commit copies the files to `/etc/systemd/system`.

This is on an updated copy of Raspbian:
```
pi@raspberrypi:~/Pimoroni/hyperpixel $ cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 8 (jessie)"
NAME="Raspbian GNU/Linux"
VERSION_ID="8"
```